### PR TITLE
Fixed broken link in getstarted_data.md

### DIFF
--- a/docs/source/1_getstarted/getstarted_data.md
+++ b/docs/source/1_getstarted/getstarted_data.md
@@ -4,7 +4,8 @@
 
 <br>  
 
-The data are hosted and can be accessed on the MEOM server opendap [here](https://ige-meom-opendap.univ-grenoble-alpes.fr/thredds/catalog/meomopendap/extract/ocean-data-challenges/dc_Map_global_OSE/catalog.html). The disk space needed to locally download the full dataset (for the reconstruction experiment, the independant evaluation and the comparison) is approximately 33Go. The comparison data is by far the heaviest with approximately 26Go. 
+The data are hosted and can be accessed on the MEOM server opendap [here](https://ige-meom-opendap.univ-grenoble-alpes.fr/thredds/catalog/meomopendap/extract/MEOM/OCEAN_DATA_CHALLENGES/2023a_SSH_mapping_OSE/catalog.html).
+The disk space needed to locally download the full dataset (for the reconstruction experiment, the independant evaluation and the comparison) is approximately 33Go. The comparison data is by far the heaviest with approximately 26Go. 
 
 ## Data information
 


### PR DESCRIPTION
It seems like the directory structure in the opendap server changed and that broke the link; this should fix that.